### PR TITLE
TASK: Make TemplateMailer PHP7.2 ready by allowing pelago/emogrifier 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "neos/flow": "^4.0",
         "neos/swiftmailer": "^6.0",
-        "pelago/emogrifier": "^1.1"
+        "pelago/emogrifier": "^1.1 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes #1 

Based on the Changelog https://github.com/MyIntervals/emogrifier/blob/master/CHANGELOG.md and my short local tests, there should be no problems in switching to the next major version.