### PR TITLE
Allow `pelago/emogrifier` v7, raise minium Flow version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "source": "https://github.com/sandstorm/TemplateMailer"
     },
     "require": {
-        "neos/flow": "^6.0 || ^7.0 || ^8.0 || dev-master",
+        "neos/flow": "^7.3 || ^8.0 || dev-main",
         "neos/swiftmailer": "^7.0",
-        "pelago/emogrifier": "^6.0"
+        "pelago/emogrifier": "^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This allows the use PHP 8.2 & 8.3, since that is supported as of 7.0 and .1 respectively.

Also, remove support for outdated Flow versions.

Fixes #12 